### PR TITLE
Avoid logging Kafka configuration values

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -6,7 +6,7 @@ using namespace Rcpp;
 #ifndef __UTILITIES__
 #define __UTILITIES__
 
-inline RdKafka::Conf* generate_kafka_config(Rcpp::List conf_) {
+inline RdKafka::Conf* generate_kafka_config(Rcpp::List conf_, bool verbose = false) {
     RdKafka::Conf *conf;
     std::string errstr;
 
@@ -23,9 +23,10 @@ inline RdKafka::Conf* generate_kafka_config(Rcpp::List conf_) {
         {
             Rcpp::warning(errstr);
         }
-        else
-        {
-            Rcpp::Rcout << "Configuration property set: " << key << " = " << value << std::endl;
+        else if (verbose)
+        {   
+            // Do not print configuration values as they may contain credentials.
+            Rcpp::Rcout << "Configuration property set: " << key << std::endl;
         }
     }
 

--- a/tests/testthat/test-config-logging.R
+++ b/tests/testthat/test-config-logging.R
@@ -1,0 +1,15 @@
+test_that("Kafka config values are not printed by default", {
+  secret <- "super-secret-password-should-not-be-logged"
+  
+  config_producer <- list(
+    "bootstrap.servers" = brokers,
+    "sasl.username" = "test-user",
+    "sasl.password" = secret
+  )
+  
+  output <- capture.output({
+    producer <- Producer$new(config_producer)
+  })
+  
+  expect_false(any(grepl(secret, output, fixed = TRUE)))
+})


### PR DESCRIPTION
## Summary

This PR prevents Kafka configuration values from being written to logs, as they may contain sensitive information such as credentials.

## Changes

- Add an optional `verbose` parameter to `generate_kafka_config()`, defaulting to `false`.
- Disable configuration logging by default.
- When `verbose` is enabled, log only the configuration key, never the corresponding value.

## Motivation

Previously, all Kafka configuration values were written to the log after being set successfully. This could expose secrets (e.g. `sasl.password`, tokens, or other credentials) in centralized logging systems such as CloudWatch.

This change preserves optional debug logging while avoiding accidental disclosure of sensitive information.